### PR TITLE
modifications

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,17 @@
 name := "ConceptAlignment"
 organization := "org.clulab"
 
-resolvers +=  "Artifactory" at "http://artifactory.cs.arizona.edu:8081/artifactory/sbt-release" // processors-models
+resolvers ++= Seq(
+  "jitpack" at "https://jitpack.io", // com.github.WorldModelers/Ontologies
+  "Artifactory" at "http://artifactory.cs.arizona.edu:8081/artifactory/sbt-release" // org.clulab/glove-840b-300d
+)
 
 val procVer = "8.0.2"
 
 libraryDependencies ++= Seq(
   "org.clulab"    %% "processors-main"          % procVer,
   "org.clulab"    %% "processors-corenlp"       % procVer,
+  "org.clulab"    %% "eidos"                    % "1.1.0-SNAPSHOT",
   "ai.lum"        %% "common"                   % "0.0.10",
   "com.lihaoyi"   %% "ujson"                    % "0.7.1",
   "com.lihaoyi"   %% "upickle"                  % "0.7.1",

--- a/src/main/scala/org/clulab/alignment/Aligner.scala
+++ b/src/main/scala/org/clulab/alignment/Aligner.scala
@@ -1,10 +1,39 @@
 package org.clulab.alignment
 
-case class Concept(name: String, embedding: Array[Float])
+// Classes to hold the concepts, as well as any metadata that may arise
+class Concept(val name: String)
+class FlatConcept(name: String, val embedding: Array[Float]) extends Concept(name)
+class CompositionalConcept(name: String, val base: FlatConcept, val arguments: Seq[ArgumentConcept]) extends Concept(name)
 
-case class Score(name: String, value: Float)
+case class ArgumentConcept(role: String, concept: FlatConcept)
+case class ConceptSequence(concepts: Seq[Concept])
+
+// Class to hold the scoring info, as well as the concepts being scored and the method used
+case class ScoredPair(scoringMethod: String, src: Concept, dst: Concept, value: Float)
 
 trait Aligner {
   val name: String
-  def align(c1: Concept, c2: Concept): Score
+  def align(c1: Concept, c2: Concept): ScoredPair
+
+  // top k for a given source concept, from a provided list
+  def topk(src: Concept, dsts: ConceptSequence, k: Int): Seq[ScoredPair] = {
+    // Align the src to each of the dsts, sort descending, and take the top k
+    dsts.concepts.map(dst => align(src, dst)).sortBy(- _.value).take(k)
+  }
+
+  // Exhaustive alignment between two concepts lists, unsorted
+  def alignAll(srcs: ConceptSequence, dsts: ConceptSequence): Seq[ScoredPair] = {
+    for {
+      src <- srcs.concepts
+      dst <- dsts.concepts
+    } yield align(src, dst)
+  }
+
+  def getEmbedding(c: Concept): Array[Float] = {
+    c match {
+      case f: FlatConcept => f.embedding
+      case comp: CompositionalConcept => comp.base.embedding
+      case _ => ???
+    }
+  }
 }

--- a/src/main/scala/org/clulab/alignment/EmbeddingOnlyAligner.scala
+++ b/src/main/scala/org/clulab/alignment/EmbeddingOnlyAligner.scala
@@ -4,8 +4,8 @@ class EmbeddingOnlyAligner extends Aligner {
 
   val name = "EmbeddingOnly"
 
-  override def align(c1: Concept, c2: Concept): Score = {
-    val similarity = dotProduct(c1.embedding, c2.embedding)
-    Score(name, similarity)
+  override def align(c1: Concept, c2: Concept): ScoredPair = {
+    val similarity = dotProduct(getEmbedding(c1), getEmbedding(c2))
+    ScoredPair(name, c1, c2, similarity)
   }
 }

--- a/src/main/scala/org/clulab/alignment/Example.scala
+++ b/src/main/scala/org/clulab/alignment/Example.scala
@@ -1,0 +1,21 @@
+package org.clulab.alignment
+
+import org.clulab.alignment.utils.ConceptUtils
+
+object Example extends App {
+
+  // Get the WM ontology(ies) being used and convert to the local data structure
+  val TDConcepts = ConceptUtils.conceptsFromWMOntology("wm_flat")
+
+  val aligner = WeightedParentSimilarityAligner.fromConfig()
+
+  val indicatorExamples = Seq(
+    "Annual growth US$ Gross Domestic Product per capita",
+    "Area Agricultural area organic, total",
+    "Area harvested Maize",
+  ).map(ConceptUtils.conceptBOWFromString(_, aligner.w2v, flat = true))
+
+  val top5 = indicatorExamples.flatMap(indicator => aligner.topk(indicator, TDConcepts, 5))
+  top5 foreach println
+
+}

--- a/src/main/scala/org/clulab/alignment/utils/ConceptUtils.scala
+++ b/src/main/scala/org/clulab/alignment/utils/ConceptUtils.scala
@@ -1,0 +1,30 @@
+package org.clulab.alignment.utils
+
+import org.clulab.alignment.{CompositionalConcept, Concept, ConceptSequence, FlatConcept}
+import org.clulab.embeddings.word2vec.Word2Vec
+import org.clulab.wm.eidos.groundings.{EidosOntologyGrounder, OntologyHandler}
+
+object ConceptUtils {
+
+  lazy val ontologyHandler = OntologyHandler.fromConfig()
+
+  def conceptBOWFromString(s: String, w2v: Word2Vec, flat: Boolean): Concept = {
+    val tokens = s.split(" ").map(_.trim.toLowerCase())
+    val emb = w2v.makeCompositeVector(tokens).map(_.toFloat)
+    val flatConcept = new FlatConcept(s, emb)
+    if (flat) {
+      flatConcept
+    } else {
+      new CompositionalConcept(s, flatConcept, Seq())
+    }
+  }
+
+  def conceptsFromWMOntology(namespace: String): ConceptSequence = {
+    val TDOntology = ontologyHandler.ontologyGrounders
+      .collect { case grounder: EidosOntologyGrounder => grounder}
+      .find { grounder => grounder.name == namespace }.get
+    val TDConceptEmbeddings = TDOntology.conceptEmbeddings
+    ConceptSequence(TDConceptEmbeddings.map(ce => new FlatConcept(ce.namer.name, ce.embedding)))
+  }
+
+}


### PR DESCRIPTION
@MihaiSurdeanu this is my draft of what you were hoping for.  

There is an Aligner trait which has built in methods for align, topk, and alignAll.  Further,
there is some structure in place to handle compositional grounding, I tried to guide it
with the current discussion (i.e., args and all).

There are still only 2 Aligners implemented -- a super basic w2v similarity and the WeightedParent one that 
was most recently used for mapping in WM.  Note that the latter would need some thinking
before it's ready for compositional nodes, unless they're simply flattened (which can be done).

Also included is Example.scala, an App that shows how one would interact with an Aligner from the outside.
This is largely similar to what @zhengzhongliang had done, though I am just printing, while he had a use case.

so, @MihaiSurdeanu please let me know if this is on track.  It's not ready for prime time bc there are no tests or anything, but I was secretly hoping @zhengzhongliang could work on that...?